### PR TITLE
Moving header and footer out to its own html, adding new teams and about pages

### DIFF
--- a/content/about/_index.md
+++ b/content/about/_index.md
@@ -1,0 +1,38 @@
+---
+title: "About Illuminaite"
+date: 2024-10-31
+author: "Illuminaite Team"
+image: images/blog/logo.png
+description: "Learn about Illuminaite Academy's mission and vision in demystifying CS & AI education."
+---
+
+# About Illuminaite
+
+## Our Mission
+At Illuminaite Academy, we believe that computer science and artificial intelligence education should be accessible to everyone. Our mission is to demystify complex technical concepts and create a vibrant community of interdisciplinary learners.
+
+## Who We Are
+We are a team of passionate educators, technologists, and innovators committed to breaking down barriers in tech education. Our diverse team brings together expertise from various fields to create comprehensive, accessible learning experiences.
+
+## What We Do
+- Educational Content Creation
+- Community Building
+- Interdisciplinary Learning
+- Skill Development
+- Practical Workshops
+
+## Our Values
+- **Accessibility:** Making technical education available to everyone
+- **Clarity:** Breaking down complex concepts into understandable pieces
+- **Community:** Building a supportive network of learners
+- **Innovation:** Staying current with the latest technological advances
+- **Inclusivity:** Welcoming learners from all backgrounds
+
+## Our Impact
+- 300+ participants across all age groups
+- Present in 40+ cities worldwide
+- Reaching learners in 10+ countries
+- 15+ dedicated team members working to expand our mission
+
+## Get Involved
+Join our community and be part of the journey to make tech education more accessible and engaging.

--- a/public/about/index.html
+++ b/public/about/index.html
@@ -1,0 +1,144 @@
+<!DOCTYPE html>
+<html lang="en-us">
+<head>
+  <meta charset="utf-8" />
+  <title>About Illuminaite</title>
+
+  <!-- mobile responsive meta -->
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" />
+  
+  <meta name="author" content="Illuminaite Academy">
+  
+  <meta name="generator" content="Hugo 0.135.0">
+
+  <!-- Bootstrap -->
+  <link rel="stylesheet" href="http://localhost:1313/css/bootstrap.min.css" />
+  <!-- font-awesome -->
+  <link rel="stylesheet" href="http://localhost:1313/font-awesome/css/font-awesome.min.css" />
+  <!-- Main Stylesheets -->
+  <link href="http://localhost:1313/scss/style.min.css" rel="stylesheet" />
+
+  <link rel="shortcut icon" href="http://localhost:1313/images/logo.png" type="image/x-icon" />
+  <link rel="icon" href="http://localhost:1313/" type="image/x-icon" />
+
+  <!-- Load jQuery and Bootstrap first -->
+  <script src="http://localhost:1313/js/vendor.min.js"></script>
+  <script src="http://localhost:1313/js/script.min.js"></script>
+
+  <!-- Header and Footer loading script -->
+  <script>
+    document.addEventListener('DOMContentLoaded', function() {
+      // Load header
+      fetch('/header.html')
+        .then(response => response.text())
+        .then(data => {
+          document.getElementById('header').innerHTML = data;
+        })
+        .catch(error => console.error('Error loading header:', error));
+
+      // Load footer
+      fetch('/footer.html')
+        .then(response => response.text())
+        .then(data => {
+          document.getElementById('footer').innerHTML = data;
+        })
+        .catch(error => console.error('Error loading footer:', error));
+    });
+  </script>
+</head>
+<body>
+  <div id="header"></div>
+
+  <main>
+    <section class="site-blog details">
+      <div class="container">
+        <div class="row justify-content-center">
+          <div class="col-lg-8">
+            <article class="site-blog-details">
+              <h2 class="blog-title">About Illuminaite</h2>
+              <img class="feature-image" src="http://localhost:1313/images/blog/logo.png" alt="about-feature-image">
+              
+              <h2>Our Mission</h2>
+              <p>At Illuminaite Academy, we believe that computer science and artificial intelligence education should be accessible to everyone. Our mission is to demystify complex technical concepts and create a vibrant community of interdisciplinary learners.</p>
+              
+              <h2>Who We Are</h2>
+              <p>We are a team of passionate educators, technologists, and innovators committed to breaking down barriers in tech education. Our diverse team brings together expertise from various fields to create comprehensive, accessible learning experiences.</p>
+
+              <div class="highlight">
+                <div class="row text-center">
+                  <div class="col-md-3">
+                    <div class="stat-item">
+                      <h3>300+</h3>
+                      <p>Participants</p>
+                    </div>
+                  </div>
+                  <div class="col-md-3">
+                    <div class="stat-item">
+                      <h3>40+</h3>
+                      <p>Cities</p>
+                    </div>
+                  </div>
+                  <div class="col-md-3">
+                    <div class="stat-item">
+                      <h3>10+</h3>
+                      <p>Countries</p>
+                    </div>
+                  </div>
+                  <div class="col-md-3">
+                    <div class="stat-item">
+                      <h3>15+</h3>
+                      <p>Team Members</p>
+                    </div>
+                  </div>
+                </div>
+              </div>
+
+              <h2>Our Values</h2>
+              <ul>
+                <li><strong>Accessibility:</strong> Making technical education available to everyone</li>
+                <li><strong>Clarity:</strong> Breaking down complex concepts into understandable pieces</li>
+                <li><strong>Community:</strong> Building a supportive network of learners</li>
+                <li><strong>Innovation:</strong> Staying current with the latest technological advances</li>
+                <li><strong>Inclusivity:</strong> Welcoming learners from all backgrounds</li>
+              </ul>
+
+              <h2>Get Involved</h2>
+              <p>Join our community and be part of the journey to make tech education more accessible and engaging.</p>
+            </article>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="site-cta" style='background-image: url("http://localhost:1313/");'>
+      <div class="container">
+        <div class="row">
+          <div class="col-12 text-center">
+            <h1 class="site-cta-title">LET'S WORK TOGETHER</h1>
+            <ul class="site-cta-buttons">
+              <li>
+                <a href="http://localhost:1313/contact" class="btn btn-secondary">
+                  <span class="btn-area">
+                    <span data-text="Submit Query">Submit Query</span>
+                  </span>
+                </a>
+              </li>
+              <li>
+                <a href="http://localhost:1313/portfolio" class="btn btn-primary">
+                  <span class="btn-area">
+                    <span data-text="Not Convinced">Not Convinced</span>
+                  </span>
+                </a>
+              </li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </section>
+</main>
+
+<!-- Footer will be loaded here -->
+<div id="footer"></div>
+</body>
+</html>

--- a/public/about/index.xml
+++ b/public/about/index.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>About Illuminaite on Illuminaite</title>
+    <link>http://localhost:1313/about/</link>
+    <description>Recent content in About Illuminaite on Illuminaite</description>
+    <generator>Hugo</generator>
+    <language>en-us</language>
+    <lastBuildDate></lastBuildDate>
+    <atom:link href="http://localhost:1313/about/index.xml" rel="self" type="application/rss+xml" />
+  </channel>
+</rss>

--- a/public/blog/index.html
+++ b/public/blog/index.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
-<html lang="en-us"><head><script src="/livereload.js?mindelay=10&amp;v=2&amp;port=1313&amp;path=livereload" data-no-instant defer></script>
+<html lang="en-us">
+<head>
   <meta charset="utf-8" />
-  <title>Illuminaite Content!</title>
+  <title>About Illuminaite</title>
 
   <!-- mobile responsive meta -->
   <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -12,92 +13,43 @@
   <meta name="generator" content="Hugo 0.135.0">
 
   <!-- Bootstrap -->
-  
   <link rel="stylesheet" href="http://localhost:1313/css/bootstrap.min.css" />
   <!-- font-awesome -->
   <link rel="stylesheet" href="http://localhost:1313/font-awesome/css/font-awesome.min.css" />
   <!-- Main Stylesheets -->
-  
   <link href="http://localhost:1313/scss/style.min.css" rel="stylesheet" />
 
-  
-
-  
   <link rel="shortcut icon" href="http://localhost:1313/images/logo.png" type="image/x-icon" />
   <link rel="icon" href="http://localhost:1313/" type="image/x-icon" />
-</head>
-<body><nav class="navbar navbar-expand-lg site-navigation">
-  <div class="container">
-    <a class="navbar-brand" href="http://localhost:1313/">
-      <img src="http://localhost:1313/images/logo.png" alt="logo" />
-    </a>
-    <button
-      class="navbar-toggler collapsed"
-      type="button"
-      data-toggle="collapse"
-      data-target="#sitenavbar"
-    >
-      <span class="icon-bar"></span>
-      <span class="icon-bar"></span>
-      <span class="icon-bar"></span>
-    </button>
 
-    <div class="collapse navbar-collapse" id="sitenavbar">
-      <ul class="navbar-nav ml-auto main-nav">
-         
-         
-         
-          
-          <li class="nav-item">
-            <a class="nav-link" href="http://localhost:1313/"
-              >Home</a
-            >
-          </li>
-           
-         
-          
-          <li class="nav-item">
-            <a class="nav-link" href="http://localhost:1313/about"
-              >About</a
-            >
-          </li>
-           
-         
-          
-          <li class="nav-item">
-            <a class="nav-link" href="http://localhost:1313/portfolio"
-              >Portfolio</a
-            >
-          </li>
-           
-         
-          
-          <li class="nav-item">
-            <a class="nav-link" href="http://localhost:1313/blog"
-              >Blog</a
-            >
-          </li>
-           
-         
-          
-          <li class="nav-item">
-            <a
-              class="nav-link btn btn-sm btn-primary btn-sm-rounded"
-              href="http://localhost:1313/contact"
-            >
-              <span class="btn-area">
-                <span data-text="Contact Us">
-                  Contact Us
-                </span>
-              </span>
-            </a>
-          </li>
-           
-        
-      </ul>
-    </div>
-  </div>
-</nav>
+  <!-- Load jQuery and Bootstrap first -->
+  <script src="http://localhost:1313/js/vendor.min.js"></script>
+  <script src="http://localhost:1313/js/script.min.js"></script>
+
+  <!-- Header and Footer loading script -->
+  <script>
+    document.addEventListener('DOMContentLoaded', function() {
+      // Load header
+      fetch('/header.html')
+        .then(response => response.text())
+        .then(data => {
+          document.getElementById('header').innerHTML = data;
+        })
+        .catch(error => console.error('Error loading header:', error));
+
+      // Load footer
+      fetch('/footer.html')
+        .then(response => response.text())
+        .then(data => {
+          document.getElementById('footer').innerHTML = data;
+        })
+        .catch(error => console.error('Error loading footer:', error));
+    });
+  </script>
+</head>
+<body>
+  <div id="header"></div>
+
 <main>
 
 <section class="site-blog-header">
@@ -182,100 +134,9 @@
 
 
 
-        </main><footer class="site-footer">
-  <div class="container">
-    <div class="row">
-      <div class="col-12">
-        <div class="site-footer-logo"><a href="http://localhost:1313/"><img src="http://localhost:1313/images/logo.png" alt="logo-footer"></a></div>
-      </div>
-      
-      <div class="col-lg-3 col-md-6">
-        <div class="site-footer-widget">
-          <h5 class="site-footer-widget-title">Contact Info</h5>
-          <p class="site-footer-widget-description">
-	    
-              713 Elmwood St.<br>Prior Lake, MN 55372
-	      <br>
-	    
-	    
-              <a href="tel:409-896-1444">409-896-1444</a>
-              <br>
-	    
-	    
-              <a href="mailto:info@roxo.co">info@roxo.co</a>
-	    
-          </p>
-        </div>
-      </div>
-      
-      
-      <div class="col-lg-2 col-md-6">
-        <div class="site-footer-widget">
-          <h5 class="site-footer-widget-title">Sitemap</h5>
-          <ul class="site-footer-widget-links">
-            
-            <li><a href="http://localhost:1313/about">About Company</a></li>
-            
-            <li><a href="http://localhost:1313/portfolio">Projects</a></li>
-            
-            <li><a href="http://localhost:1313/blog">Blog</a></li>
-            
-            <li><a href="http://localhost:1313/contact">Contact</a></li>
-            
-          </ul>
-        </div>
-      </div>
-      
-      
-      <div class="col-lg-2 col-md-6">
-        <div class="site-footer-widget">
-          <h5 class="site-footer-widget-title">Social Media</h5>
-          <ul class="site-footer-widget-links">
-            
-              <li><a href="#">Medium</a></li>
-            
-              <li><a href="#">Behance</a></li>
-            
-              <li><a href="#">Dribbble</a></li>
-            
-              <li><a href="#">Instagram</a></li>
-            
-          </ul>
-        </div>
-      </div>
-      
-      
-      <div class="col-lg-3 col-md-6">
-        <div class="site-footer-widget">
-          <h5 class="site-footer-widget-title">We help brands:</h5>
-          <p class="site-footer-widget-description">
-            develop design solutions<br>produce valuable cultural content<br>create fresh brand experience
-          </p>
-        </div>
-      </div>
-      
-      <div class="col-lg-2 col-12">
-        <a href="#top" class="site-footer-widget-top">
-          <img src="http://localhost:1313/images/to-top.svg" alt="back-to-top">
-          <p>
-	    I want to <br> visit again
-          </p>
-        </a>
-      </div>
-      <div class="col-12">
-        <div class="site-footer-copyright">
-          <p>© Copyright 2024 - All Rights Reserved by <a href="https://staticmania.com/" target="_blank">StaticMania</a> </p>
-        </div>
-      </div>
-    </div>
-    
-  </div>
-</footer>
+</main>
 
-
-
-<script src="http://localhost:1313/js/vendor.min.js"></script>
-
-<script src="http://localhost:1313/js/script.min.js"></script>
+        <!-- Footer will be loaded here -->
+<div id="footer"></div>
 </body>
 </html>

--- a/public/blog/intro_to_python/index.html
+++ b/public/blog/intro_to_python/index.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
-<html lang="en-us"><head><script src="/livereload.js?mindelay=10&amp;v=2&amp;port=1313&amp;path=livereload" data-no-instant defer></script>
+<html lang="en-us">
+<head>
   <meta charset="utf-8" />
-  <title>Installing Python</title>
+  <title>About Illuminaite</title>
 
   <!-- mobile responsive meta -->
   <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -12,92 +13,43 @@
   <meta name="generator" content="Hugo 0.135.0">
 
   <!-- Bootstrap -->
-  
   <link rel="stylesheet" href="http://localhost:1313/css/bootstrap.min.css" />
   <!-- font-awesome -->
   <link rel="stylesheet" href="http://localhost:1313/font-awesome/css/font-awesome.min.css" />
   <!-- Main Stylesheets -->
-  
   <link href="http://localhost:1313/scss/style.min.css" rel="stylesheet" />
 
-  
-
-  
   <link rel="shortcut icon" href="http://localhost:1313/images/logo.png" type="image/x-icon" />
   <link rel="icon" href="http://localhost:1313/" type="image/x-icon" />
-</head>
-<body><nav class="navbar navbar-expand-lg site-navigation">
-  <div class="container">
-    <a class="navbar-brand" href="http://localhost:1313/">
-      <img src="http://localhost:1313/images/logo.png" alt="logo" />
-    </a>
-    <button
-      class="navbar-toggler collapsed"
-      type="button"
-      data-toggle="collapse"
-      data-target="#sitenavbar"
-    >
-      <span class="icon-bar"></span>
-      <span class="icon-bar"></span>
-      <span class="icon-bar"></span>
-    </button>
 
-    <div class="collapse navbar-collapse" id="sitenavbar">
-      <ul class="navbar-nav ml-auto main-nav">
-         
-         
-         
-          
-          <li class="nav-item">
-            <a class="nav-link" href="http://localhost:1313/"
-              >Home</a
-            >
-          </li>
-           
-         
-          
-          <li class="nav-item">
-            <a class="nav-link" href="http://localhost:1313/about"
-              >About</a
-            >
-          </li>
-           
-         
-          
-          <li class="nav-item">
-            <a class="nav-link" href="http://localhost:1313/portfolio"
-              >Portfolio</a
-            >
-          </li>
-           
-         
-          
-          <li class="nav-item">
-            <a class="nav-link" href="http://localhost:1313/blog"
-              >Blog</a
-            >
-          </li>
-           
-         
-          
-          <li class="nav-item">
-            <a
-              class="nav-link btn btn-sm btn-primary btn-sm-rounded"
-              href="http://localhost:1313/contact"
-            >
-              <span class="btn-area">
-                <span data-text="Contact Us">
-                  Contact Us
-                </span>
-              </span>
-            </a>
-          </li>
-           
-        
-      </ul>
-    </div>
-  </div>
-</nav>
+  <!-- Load jQuery and Bootstrap first -->
+  <script src="http://localhost:1313/js/vendor.min.js"></script>
+  <script src="http://localhost:1313/js/script.min.js"></script>
+
+  <!-- Header and Footer loading script -->
+  <script>
+    document.addEventListener('DOMContentLoaded', function() {
+      // Load header
+      fetch('/header.html')
+        .then(response => response.text())
+        .then(data => {
+          document.getElementById('header').innerHTML = data;
+        })
+        .catch(error => console.error('Error loading header:', error));
+
+      // Load footer
+      fetch('/footer.html')
+        .then(response => response.text())
+        .then(data => {
+          document.getElementById('footer').innerHTML = data;
+        })
+        .catch(error => console.error('Error loading footer:', error));
+    });
+  </script>
+</head>
+<body>
+  <div id="header"></div>
+
 <main>
 
 <section class="site-blog details">
@@ -191,104 +143,10 @@
       </div>
     </div>
   </section>
-  
 
+</main>
 
-
-        </main><footer class="site-footer">
-  <div class="container">
-    <div class="row">
-      <div class="col-12">
-        <div class="site-footer-logo"><a href="http://localhost:1313/"><img src="http://localhost:1313/images/logo.png" alt="logo-footer"></a></div>
-      </div>
-      
-      <div class="col-lg-3 col-md-6">
-        <div class="site-footer-widget">
-          <h5 class="site-footer-widget-title">Contact Info</h5>
-          <p class="site-footer-widget-description">
-	    
-              713 Elmwood St.<br>Prior Lake, MN 55372
-	      <br>
-	    
-	    
-              <a href="tel:409-896-1444">409-896-1444</a>
-              <br>
-	    
-	    
-              <a href="mailto:info@roxo.co">info@roxo.co</a>
-	    
-          </p>
-        </div>
-      </div>
-      
-      
-      <div class="col-lg-2 col-md-6">
-        <div class="site-footer-widget">
-          <h5 class="site-footer-widget-title">Sitemap</h5>
-          <ul class="site-footer-widget-links">
-            
-            <li><a href="http://localhost:1313/about">About Company</a></li>
-            
-            <li><a href="http://localhost:1313/portfolio">Projects</a></li>
-            
-            <li><a href="http://localhost:1313/blog">Blog</a></li>
-            
-            <li><a href="http://localhost:1313/contact">Contact</a></li>
-            
-          </ul>
-        </div>
-      </div>
-      
-      
-      <div class="col-lg-2 col-md-6">
-        <div class="site-footer-widget">
-          <h5 class="site-footer-widget-title">Social Media</h5>
-          <ul class="site-footer-widget-links">
-            
-              <li><a href="#">Medium</a></li>
-            
-              <li><a href="#">Behance</a></li>
-            
-              <li><a href="#">Dribbble</a></li>
-            
-              <li><a href="#">Instagram</a></li>
-            
-          </ul>
-        </div>
-      </div>
-      
-      
-      <div class="col-lg-3 col-md-6">
-        <div class="site-footer-widget">
-          <h5 class="site-footer-widget-title">We help brands:</h5>
-          <p class="site-footer-widget-description">
-            develop design solutions<br>produce valuable cultural content<br>create fresh brand experience
-          </p>
-        </div>
-      </div>
-      
-      <div class="col-lg-2 col-12">
-        <a href="#top" class="site-footer-widget-top">
-          <img src="http://localhost:1313/images/to-top.svg" alt="back-to-top">
-          <p>
-	    I want to <br> visit again
-          </p>
-        </a>
-      </div>
-      <div class="col-12">
-        <div class="site-footer-copyright">
-          <p>© Copyright 2024 - All Rights Reserved by <a href="https://staticmania.com/" target="_blank">StaticMania</a> </p>
-        </div>
-      </div>
-    </div>
-    
-  </div>
-</footer>
-
-
-
-<script src="http://localhost:1313/js/vendor.min.js"></script>
-
-<script src="http://localhost:1313/js/script.min.js"></script>
+<!-- Footer will be loaded here -->
+<div id="footer"></div>
 </body>
 </html>

--- a/public/footer.html
+++ b/public/footer.html
@@ -1,0 +1,76 @@
+<footer class="site-footer">
+    <div class="container">
+      <div class="row">
+        <div class="col-12">
+          <div class="site-footer-logo">
+            <a href="/">
+              <img src="/images/logo.png" alt="logo-footer">
+            </a>
+          </div>
+        </div>
+        
+        <div class="col-lg-3 col-md-6">
+          <div class="site-footer-widget">
+            <h5 class="site-footer-widget-title">Contact Info</h5>
+            <p class="site-footer-widget-description">
+             hello.<br>Prior Lake, MN 55372<br>
+              <a href="tel:409-896-1444">409-896-1444</a><br>
+              <a href="mailto:info@roxo.co">info@roxo.co</a>
+            </p>
+          </div>
+        </div>
+        
+        <div class="col-lg-2 col-md-6">
+          <div class="site-footer-widget">
+            <h5 class="site-footer-widget-title">Sitemap</h5>
+            <ul class="site-footer-widget-links">
+              <li><a href="/about">About Company</a></li>
+              <li><a href="/portfolio">Projects</a></li>
+              <li><a href="/blog">Blog</a></li>
+              <li><a href="/contact">Contact</a></li>
+            </ul>
+          </div>
+        </div>
+        
+        <div class="col-lg-2 col-md-6">
+          <div class="site-footer-widget">
+            <h5 class="site-footer-widget-title">Social Media</h5>
+            <ul class="site-footer-widget-links">
+              <li><a href="#">Medium</a></li>
+              <li><a href="#">Behance</a></li>
+              <li><a href="#">Dribbble</a></li>
+              <li><a href="#">Instagram</a></li>
+            </ul>
+          </div>
+        </div>
+        
+        <div class="col-lg-3 col-md-6">
+          <div class="site-footer-widget">
+            <h5 class="site-footer-widget-title">We help brands:</h5>
+            <p class="site-footer-widget-description">
+              develop design solutions<br>produce valuable cultural content<br>create fresh brand experience
+            </p>
+          </div>
+        </div>
+        
+        <div class="col-lg-2 col-12">
+          <a href="#top" class="site-footer-widget-top">
+            <img src="/images/to-top.svg" alt="back-to-top">
+            <p>I want to <br> visit again</p>
+          </a>
+        </div>
+        
+        <div class="col-12">
+          <div class="site-footer-copyright">
+            <p>© Copyright 2024 - All Rights Reserved by <a href="https://staticmania.com/" target="_blank">StaticMania</a></p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </footer>
+  
+  <!-- JS Plugins -->
+  <script src="/js/vendor.min.js"></script>
+  <script src="/js/script.min.js"></script>
+  </body>
+  </html>

--- a/public/header.html
+++ b/public/header.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="en-us">
+<head>
+  <meta charset="utf-8" />
+  <title>About Illuminaite</title>
+
+  <!-- mobile responsive meta -->
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" />
+  
+  <meta name="author" content="Illuminaite Academy">
+  
+  <meta name="generator" content="Hugo 0.135.0">
+
+  <!-- Bootstrap -->
+  <link rel="stylesheet" href="/css/bootstrap.min.css" />
+  <!-- font-awesome -->
+  <link rel="stylesheet" href="/font-awesome/css/font-awesome.min.css" />
+  <!-- Main Stylesheets -->
+  <link href="/scss/style.min.css" rel="stylesheet" />
+
+  <link rel="shortcut icon" href="/images/logo.png" type="image/x-icon" />
+  <link rel="icon" href="/" type="image/x-icon" />
+</head>
+<body>
+  <!-- Navigation Bar -->
+  <nav class="navbar navbar-expand-lg site-navigation">
+    <div class="container">
+      <a class="navbar-brand" href="/">
+        <img src="/images/logo.png" alt="logo" />
+      </a>
+      <button class="navbar-toggler collapsed" type="button" data-toggle="collapse" data-target="#sitenavbar">
+        <span class="icon-bar"></span>
+        <span class="icon-bar"></span>
+        <span class="icon-bar"></span>
+      </button>
+
+      <div class="collapse navbar-collapse" id="sitenavbar">
+        <ul class="navbar-nav ml-auto main-nav">
+          <li class="nav-item">
+            <a class="nav-link" href="/">Home</a>
+          </li>
+          <li class="nav-item">
+            <a class="nav-link" href="/about">About</a>
+          </li>
+          <li class="nav-item">
+            <a class="nav-link" href="/team">Team</a>
+          </li>
+          <li class="nav-item">
+            <a class="nav-link" href="/blog">Blog</a>
+          </li>
+          <li class="nav-item">
+            <a class="nav-link btn btn-sm btn-primary btn-sm-rounded" href="/contact">
+              <span class="btn-area">
+                <span data-text="Contact Us">Contact Us</span>
+              </span>
+            </a>
+          </li>
+        </ul>
+      </div>
+    </div>
+  </nav>

--- a/public/index.html
+++ b/public/index.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
-<html lang="en-us"><head><script src="/livereload.js?mindelay=10&amp;v=2&amp;port=1313&amp;path=livereload" data-no-instant defer></script>
+<html lang="en-us">
+<head>
   <meta charset="utf-8" />
-  <title>Illuminaite</title>
+  <title>About Illuminaite</title>
 
   <!-- mobile responsive meta -->
   <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -12,92 +13,43 @@
   <meta name="generator" content="Hugo 0.135.0">
 
   <!-- Bootstrap -->
-  
   <link rel="stylesheet" href="http://localhost:1313/css/bootstrap.min.css" />
   <!-- font-awesome -->
   <link rel="stylesheet" href="http://localhost:1313/font-awesome/css/font-awesome.min.css" />
   <!-- Main Stylesheets -->
-  
   <link href="http://localhost:1313/scss/style.min.css" rel="stylesheet" />
 
-  
-
-  
   <link rel="shortcut icon" href="http://localhost:1313/images/logo.png" type="image/x-icon" />
   <link rel="icon" href="http://localhost:1313/" type="image/x-icon" />
-</head>
-<body><nav class="navbar navbar-expand-lg site-navigation">
-  <div class="container">
-    <a class="navbar-brand" href="http://localhost:1313/">
-      <img src="http://localhost:1313/images/logo.png" alt="logo" />
-    </a>
-    <button
-      class="navbar-toggler collapsed"
-      type="button"
-      data-toggle="collapse"
-      data-target="#sitenavbar"
-    >
-      <span class="icon-bar"></span>
-      <span class="icon-bar"></span>
-      <span class="icon-bar"></span>
-    </button>
 
-    <div class="collapse navbar-collapse" id="sitenavbar">
-      <ul class="navbar-nav ml-auto main-nav">
-         
-         
-         
-          
-          <li class="nav-item">
-            <a class="nav-link" href="http://localhost:1313/"
-              >Home</a
-            >
-          </li>
-           
-         
-          
-          <li class="nav-item">
-            <a class="nav-link" href="http://localhost:1313/about"
-              >About</a
-            >
-          </li>
-           
-         
-          
-          <li class="nav-item">
-            <a class="nav-link" href="http://localhost:1313/portfolio"
-              >Portfolio</a
-            >
-          </li>
-           
-         
-          
-          <li class="nav-item">
-            <a class="nav-link" href="http://localhost:1313/blog"
-              >Blog</a
-            >
-          </li>
-           
-         
-          
-          <li class="nav-item">
-            <a
-              class="nav-link btn btn-sm btn-primary btn-sm-rounded"
-              href="http://localhost:1313/contact"
-            >
-              <span class="btn-area">
-                <span data-text="Contact Us">
-                  Contact Us
-                </span>
-              </span>
-            </a>
-          </li>
-           
-        
-      </ul>
-    </div>
-  </div>
-</nav>
+  <!-- Load jQuery and Bootstrap first -->
+  <script src="http://localhost:1313/js/vendor.min.js"></script>
+  <script src="http://localhost:1313/js/script.min.js"></script>
+
+  <!-- Header and Footer loading script -->
+  <script>
+    document.addEventListener('DOMContentLoaded', function() {
+      // Load header
+      fetch('/header.html')
+        .then(response => response.text())
+        .then(data => {
+          document.getElementById('header').innerHTML = data;
+        })
+        .catch(error => console.error('Error loading header:', error));
+
+      // Load footer
+      fetch('/footer.html')
+        .then(response => response.text())
+        .then(data => {
+          document.getElementById('footer').innerHTML = data;
+        })
+        .catch(error => console.error('Error loading footer:', error));
+    });
+  </script>
+</head>
+<body>
+  <div id="header"></div>
+
 <main>
 
 
@@ -269,100 +221,9 @@
 
 
 
-        </main><footer class="site-footer">
-  <div class="container">
-    <div class="row">
-      <div class="col-12">
-        <div class="site-footer-logo"><a href="http://localhost:1313/"><img src="http://localhost:1313/images/logo.png" alt="logo-footer"></a></div>
-      </div>
-      
-      <div class="col-lg-3 col-md-6">
-        <div class="site-footer-widget">
-          <h5 class="site-footer-widget-title">Contact Info</h5>
-          <p class="site-footer-widget-description">
-	    
-              713 Elmwood St.<br>Prior Lake, MN 55372
-	      <br>
-	    
-	    
-              <a href="tel:409-896-1444">409-896-1444</a>
-              <br>
-	    
-	    
-              <a href="mailto:info@roxo.co">info@roxo.co</a>
-	    
-          </p>
-        </div>
-      </div>
-      
-      
-      <div class="col-lg-2 col-md-6">
-        <div class="site-footer-widget">
-          <h5 class="site-footer-widget-title">Sitemap</h5>
-          <ul class="site-footer-widget-links">
-            
-            <li><a href="http://localhost:1313/about">About Company</a></li>
-            
-            <li><a href="http://localhost:1313/portfolio">Projects</a></li>
-            
-            <li><a href="http://localhost:1313/blog">Blog</a></li>
-            
-            <li><a href="http://localhost:1313/contact">Contact</a></li>
-            
-          </ul>
-        </div>
-      </div>
-      
-      
-      <div class="col-lg-2 col-md-6">
-        <div class="site-footer-widget">
-          <h5 class="site-footer-widget-title">Social Media</h5>
-          <ul class="site-footer-widget-links">
-            
-              <li><a href="#">Medium</a></li>
-            
-              <li><a href="#">Behance</a></li>
-            
-              <li><a href="#">Dribbble</a></li>
-            
-              <li><a href="#">Instagram</a></li>
-            
-          </ul>
-        </div>
-      </div>
-      
-      
-      <div class="col-lg-3 col-md-6">
-        <div class="site-footer-widget">
-          <h5 class="site-footer-widget-title">We help brands:</h5>
-          <p class="site-footer-widget-description">
-            develop design solutions<br>produce valuable cultural content<br>create fresh brand experience
-          </p>
-        </div>
-      </div>
-      
-      <div class="col-lg-2 col-12">
-        <a href="#top" class="site-footer-widget-top">
-          <img src="http://localhost:1313/images/to-top.svg" alt="back-to-top">
-          <p>
-	    I want to <br> visit again
-          </p>
-        </a>
-      </div>
-      <div class="col-12">
-        <div class="site-footer-copyright">
-          <p>© Copyright 2024 - All Rights Reserved by <a href="https://staticmania.com/" target="_blank">StaticMania</a> </p>
-        </div>
-      </div>
-    </div>
-    
-  </div>
-</footer>
+</main>
 
-
-
-<script src="http://localhost:1313/js/vendor.min.js"></script>
-
-<script src="http://localhost:1313/js/script.min.js"></script>
+<!-- Footer will be loaded here -->
+<div id="footer"></div>
 </body>
 </html>

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -2,8 +2,11 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
   xmlns:xhtml="http://www.w3.org/1999/xhtml">
   <url>
+    <loc>http://localhost:1313/about/</loc>
+    <lastmod>2024-10-31T00:00:00+00:00</lastmod>
+  </url><url>
     <loc>http://localhost:1313/</loc>
-    <lastmod>2024-10-25T00:00:00+00:00</lastmod>
+    <lastmod>2024-10-31T00:00:00+00:00</lastmod>
   </url><url>
     <loc>http://localhost:1313/blog/</loc>
     <lastmod>2024-10-25T00:00:00+00:00</lastmod>

--- a/public/team/index.html
+++ b/public/team/index.html
@@ -1,0 +1,317 @@
+<!DOCTYPE html>
+<html lang="en-us">
+<head>
+  <meta charset="utf-8" />
+  <title>About Illuminaite</title>
+
+  <!-- mobile responsive meta -->
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" />
+  
+  <meta name="author" content="Illuminaite Academy">
+  
+  <meta name="generator" content="Hugo 0.135.0">
+
+  <!-- Bootstrap -->
+  <link rel="stylesheet" href="http://localhost:1313/css/bootstrap.min.css" />
+  <!-- font-awesome -->
+  <link rel="stylesheet" href="http://localhost:1313/font-awesome/css/font-awesome.min.css" />
+  <!-- Main Stylesheets -->
+  <link href="http://localhost:1313/scss/style.min.css" rel="stylesheet" />
+
+  <link rel="shortcut icon" href="http://localhost:1313/images/logo.png" type="image/x-icon" />
+  <link rel="icon" href="http://localhost:1313/" type="image/x-icon" />
+
+  <!-- Your custom styles -->
+  <link rel="stylesheet" href="style.css">
+
+  <!-- Load jQuery and Bootstrap first -->
+  <script src="http://localhost:1313/js/vendor.min.js"></script>
+  <script src="http://localhost:1313/js/script.min.js"></script>
+
+  <!-- Header and Footer loading script -->
+  <script>
+    document.addEventListener('DOMContentLoaded', function() {
+      // Load header
+      fetch('/header.html')
+        .then(response => response.text())
+        .then(data => {
+          document.getElementById('header').innerHTML = data;
+        })
+        .catch(error => console.error('Error loading header:', error));
+
+      // Load footer
+      fetch('/footer.html')
+        .then(response => response.text())
+        .then(data => {
+          document.getElementById('footer').innerHTML = data;
+        })
+        .catch(error => console.error('Error loading footer:', error));
+    });
+  </script>
+</head>
+<body>
+  <div id="header"></div>
+
+  <main>
+    <section class="team-section">
+      <div class="container">
+          <div class="section-title">
+              <h2>Meet Our Team</h2>
+          </div>
+
+          <!-- Executive Team -->
+          <h3 class="subsection-title">Executive Team</h3>
+          <div class="row">
+              <!-- Co-Presidents -->
+              <div class="col-lg-4 col-md-6">
+                  <div class="team-member">
+                      <div class="member-icon">
+                          <i class="fas fa-user-tie"></i>
+                      </div>
+                      <div class="member-info">
+                          <h3>Name Here</h3>
+                          <p>Co-President</p>
+                          <p>Bio:</p>
+                          
+                      </div>
+                  </div>
+              </div>
+              
+              <div class="col-lg-4 col-md-6">
+                  <div class="team-member">
+                      <div class="member-icon">
+                          <i class="fas fa-user-tie"></i>
+                      </div>
+                      <div class="member-info">
+                          <h3>Name Here</h3>
+                          <p>Co-President</p>
+                          <p>Bio:</p>
+                        
+                      </div>
+                  </div>
+              </div>
+
+              <!-- Program Director -->
+              <div class="col-lg-4 col-md-6">
+                  <div class="team-member">
+                      <div class="member-icon">
+                          <i class="fas fa-tasks"></i>
+                      </div>
+                      <div class="member-info">
+                          <h3>Name Here</h3>
+                          <p>Program Director</p>
+                          <p>Bio:</p>
+                      
+                      </div>
+                  </div>
+              </div>
+
+              <!-- Design Director -->
+              <div class="col-lg-4 col-md-6">
+                  <div class="team-member">
+                      <div class="member-icon">
+                          <i class="fas fa-palette"></i>
+                      </div>
+                      <div class="member-info">
+                          <h3>Name Here</h3>
+                          <p>Design Director</p>
+                          <p>Bio:</p>
+                        
+                      </div>
+                  </div>
+              </div>
+
+              <!-- External Outreach x2 -->
+              <div class="col-lg-4 col-md-6">
+                  <div class="team-member">
+                      <div class="member-icon">
+                          <i class="fas fa-handshake"></i>
+                      </div>
+                      <div class="member-info">
+                          <h3>Name Here</h3>
+                          <p>External Outreach</p>
+                          <p>Bio:</p>
+            
+                      </div>
+                  </div>
+              </div>
+
+              <div class="col-lg-4 col-md-6">
+                  <div class="team-member">
+                      <div class="member-icon">
+                          <i class="fas fa-handshake"></i>
+                      </div>
+                      <div class="member-info">
+                          <h3>Name Here</h3>
+                          <p>External Outreach</p>
+                          <p>Bio:</p>
+                       
+                      </div>
+                  </div>
+              </div>
+
+              <!-- Finance Director -->
+              <div class="col-lg-4 col-md-6">
+                  <div class="team-member">
+                      <div class="member-icon">
+                          <i class="fas fa-dollar-sign"></i>
+                      </div>
+                      <div class="member-info">
+                          <h3>Name Here</h3>
+                          <p>Finance Director</p>
+                          <p>Bio:</p>
+                      
+                      </div>
+                  </div>
+              </div>
+
+              <!-- Internal Outreach x2 -->
+              <div class="col-lg-4 col-md-6">
+                  <div class="team-member">
+                      <div class="member-icon">
+                          <i class="fas fa-heart"></i>
+                      </div>
+                      <div class="member-info">
+                          <h3>Name Here</h3>
+                          <p>Internal Outreach</p>
+                          <p>Bio:</p>
+                        
+                      </div>
+                  </div>
+              </div>
+
+              <div class="col-lg-4 col-md-6">
+                  <div class="team-member">
+                      <div class="member-icon">
+                          <i class="fas fa-heart"></i>
+                      </div>
+                      <div class="member-info">
+                          <h3>Name Here</h3>
+                          <p>Internal Outreach</p>
+                          <p>Bio:</p>
+                        
+                      </div>
+                  </div>
+              </div>
+
+              <!-- Marketing Director x2 -->
+              <div class="col-lg-4 col-md-6">
+                  <div class="team-member">
+                      <div class="member-icon">
+                          <i class="fas fa-bullhorn"></i>
+                      </div>
+                      <div class="member-info">
+                          <h3>Name Here</h3>
+                          <p>Marketing Director</p>
+                          <p>Bio:</p>
+                        
+                      </div>
+                  </div>
+              </div>
+
+              
+              <div class="col-lg-4 col-md-6">
+                <div class="team-member">
+                    <div class="member-icon">
+                        <i class="fas fa-bullhorn"></i>
+                    </div>
+                    <div class="member-info">
+                        <h3>Name Here</h3>
+                        <p>Marketing Director</p>
+                        <p>Bio:</p>
+                     
+                    </div>
+                </div>
+            </div>
+
+            <div class="col-lg-4 col-md-6">
+              <div class="team-member">
+                  <div class="member-icon">
+                      <i class="fas fa-bullhorn"></i>
+                  </div>
+                  <div class="member-info">
+                      <h3>Name Here</h3>
+                      <p>Graph Designer</p>
+                      <p>Bio:</p>
+                   
+                  </div>
+              </div>
+          </div>
+
+          <div class="col-lg-4 col-md-6">
+            <div class="team-member">
+                <div class="member-icon">
+                    <i class="fas fa-bullhorn"></i>
+                </div>
+                <div class="member-info">
+                    <h3>Name Here</h3>
+                    <p>Graph Designer</p>
+                    <p>Bio:</p>
+                
+                </div>
+            </div>
+        </div>
+
+              <!-- Web Developer -->
+              <div class="col-lg-4 col-md-6">
+                  <div class="team-member">
+                      <div class="member-icon">
+                          <i class="fas fa-code"></i>
+                      </div>
+                      <div class="member-info">
+                          <h3>Name Here</h3>
+                          <p>Web Developer</p>
+                          <p>Bio:</p>
+                        
+                          </div>
+                      </div>
+                  </div>
+              </div>
+          </div>
+
+          <div class="container">
+          <!-- Content Team -->
+          <h3 class="subsection-title mt-5">Content Team</h3>
+          <div class="row">
+              <!-- Graphic Designers x2 -->
+              <div class="col-lg-4 col-md-6">
+                  <div class="team-member">
+                      <div class="member-icon">
+                          <i class="fas fa-pencil-alt"></i>
+                      </div>
+                      <div class="member-info">
+                          <h3>Name Here</h3>
+                          <p>Blog Writer</p>
+                          <p>Bio:</p>
+           
+                      </div>
+                  </div>
+              </div>
+
+              <div class="col-lg-4 col-md-6">
+                <div class="team-member">
+                    <div class="member-icon">
+                        <i class="fas fa-pencil-alt"></i>
+                    </div>
+                    <div class="member-info">
+                        <h3>Name Here</h3>
+                        <p>Blog Writer</p>
+                        <p>Bio:</p>
+         
+                    </div>
+                </div>
+            </div>
+
+          </div>
+      </div>
+  
+  </section>
+
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+</main>
+
+<!-- Footer will be loaded here -->
+<div id="footer"></div>
+</body>
+</html>

--- a/public/team/index.xml
+++ b/public/team/index.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>About Illuminaite on Illuminaite</title>
+    <link>http://localhost:1313/about/</link>
+    <description>Recent content in About Illuminaite on Illuminaite</description>
+    <generator>Hugo</generator>
+    <language>en-us</language>
+    <lastBuildDate></lastBuildDate>
+    <atom:link href="http://localhost:1313/about/index.xml" rel="self" type="application/rss+xml" />
+  </channel>
+</rss>

--- a/public/team/style.css
+++ b/public/team/style.css
@@ -1,0 +1,75 @@
+.team-section {
+    padding: 150px 0;
+    background-color: #f8f9fa;
+}
+
+.section-title {
+    margin-bottom: 60px;
+}
+
+.section-title h2 {
+    font-size: 2.5rem;
+    font-weight: 700;
+    text-align: center;
+    color: #2c3e50;
+}
+
+.section-title::after {
+    content: '';
+    display: block;
+    width: 80px;
+    height: 4px;
+    background: #0d6efd;
+    margin: 20px auto;
+}
+
+.team-member {
+    background: white;
+    border-radius: 15px;
+    padding: 30px 20px;
+    margin-bottom: 30px;
+    box-shadow: 0 5px 15px rgba(0,0,0,0.1);
+    transition: transform 0.3s ease;
+}
+
+.team-member:hover {
+    transform: translateY(-5px);
+}
+
+.member-icon {
+    width: 100px;
+    height: 100px;
+    background: #e9ecef;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    margin: 0 auto 20px;
+}
+
+.member-icon i {
+    font-size: 40px;
+    color: #0d6efd;
+}
+
+.member-info h3 {
+    font-size: 1.25rem;
+    margin-bottom: 5px;
+    text-align: center;
+    color: #2c3e50;
+}
+
+.member-info p {
+    font-size: 1rem;
+    color: #6c757d;
+    text-align: center;
+    margin-bottom: 15px;
+}
+
+
+.subsection-title {
+    font-size: 2rem;
+    color: #2c3e50;
+    text-align: center;
+    margin-bottom: 40px;
+}


### PR DESCRIPTION
The header is now its in own html, so we are able to change it without having to copy and paste into every file:

<img width="252" alt="Screenshot 2024-10-31 at 2 08 52 AM" src="https://github.com/user-attachments/assets/210e72c3-bfba-4165-a9aa-4933b8649dca">

Example usage of how to import the header and footer can be found in the changed code (I've used them in all the pages we have so far, but please follow the same format for future pages)

![Uploading Screenshot 2024-10-31 at 2.10.10 AM.png…]()

And for the footer

<img width="353" alt="Screenshot 2024-10-31 at 2 10 25 AM" src="https://github.com/user-attachments/assets/7f5d225e-c861-4ed5-bdc3-f9332ac2a07d">

As well, a very basic template is set up for you in the teams page

<img width="1200" alt="Screenshot 2024-10-31 at 1 57 32 AM" src="https://github.com/user-attachments/assets/86847dac-6595-4462-9973-2c98889aa425">


<img width="1197" alt="Screenshot 2024-10-31 at 1 57 47 AM" src="https://github.com/user-attachments/assets/d9487358-5280-4272-93a0-2e66c4d2d643">

I've also implemented an about page which we can edit later on, there's also an md file that comes with it


<img width="1048" alt="Screenshot 2024-10-31 at 1 57 58 AM" src="https://github.com/user-attachments/assets/5af24e73-a017-4220-a2ec-90006ed07439">

From now on please follow the folder organization as such, all the html, xml and css files should go in the same category folder

<img width="259" alt="Screenshot 2024-10-31 at 2 11 45 AM" src="https://github.com/user-attachments/assets/f2d97750-ace4-42fc-be77-965979ceb27b">
